### PR TITLE
Remove unnecessary xf86-video-* drivers

### DIFF
--- a/pci/graphic_drivers/nvidia-prime-render-offload/MHWDCONFIG
+++ b/pci/graphic_drivers/nvidia-prime-render-offload/MHWDCONFIG
@@ -2,7 +2,7 @@
 
 NAME="video-nvidia-prime-render-offload"
 INFO="Hybrid prime solution for NVIDIA Optimus Technology - Closed source NVIDIA driver & open source intel&amd driver."
-VERSION="2021.12.18"
+VERSION="2022.01.29"
 FREEDRIVER="false"
 PRIORITY="30"
 
@@ -37,13 +37,14 @@ DEPENDS="egl-wayland
          lib32-opencl-nvidia
          nvidia-dkms
          nvidia-prime
-         xf86-video-ati xf86-video-amdgpu xf86-video-intel xf86-video-nouveau vulkan-intel vulkan-radeon opencl-mesa
+         vulkan-intel vulkan-radeon opencl-mesa
          intel-compute-runtime intel-media-driver libvdpau-va-gl libva-intel-driver libva-mesa-driver libva-vdpau-driver
          mesa-vdpau vulkan-mesa-layers vulkan-swrast lib32-vulkan-intel lib32-vulkan-radeon lib32-opencl-mesa
          lib32-mesa-vdpau lib32-libva-intel-driver lib32-libva-mesa-driver lib32-libva-vdpau-driver
          lib32-vulkan-mesa-layers"
 
 XORGFILE="/etc/X11/mhwd.d/nvidia.conf"
+# TODO: Remove that
 UDEVFILE="/etc/udev/rules.d/90-mhwd-prime-powermanagement.rules"
 MHWDGPU_BLCKLSTNVIDIA="/etc/modprobe.d/mhwd-gpu.conf"
 MHWDGPU_MODLDNVIDIA="/etc/modules-load.d/mhwd-gpu.conf"

--- a/pci/graphic_drivers/optimus-manager/MHWDCONFIG
+++ b/pci/graphic_drivers/optimus-manager/MHWDCONFIG
@@ -2,7 +2,7 @@
 
 NAME="video-optimus-manager"
 INFO="Hybrid prime solution for NVIDIA Optimus Technology - Closed source NVIDIA driver & open source intel driver."
-VERSION="2021.08.29"
+VERSION="2022.01.29"
 FREEDRIVER="false"
 PRIORITY="31"
 
@@ -37,10 +37,6 @@ DEPENDS="egl-wayland
          optimus-manager-qt
          bbswitch-dkms
          acpi_call-dkms
-         xf86-video-ati
-         xf86-video-amdgpu
-         xf86-video-intel
-         xf86-video-nouveau
          vulkan-intel
          vulkan-radeon
          opencl-mesa


### PR DESCRIPTION
For NVIDIA PRIME Offloading to work properly only xf86-video-modesetting is required.

Co-authored-by: Soong-Vilda