### PR TITLE
Remove autogenerated Xorg config for NVIDIA

### DIFF
--- a/pci/graphic_drivers/nvidia-390xx-dkms/MHWDCONFIG
+++ b/pci/graphic_drivers/nvidia-390xx-dkms/MHWDCONFIG
@@ -23,17 +23,9 @@ DEPENDS="nvidia-390xx-utils nvidia-390xx-settings opencl-nvidia-390xx"
 DEPENDS_64="lib32-nvidia-390xx-utils lib32-opencl-nvidia-390xx"
 DEPKMOD="nvidia-390xx-dkms"
 
-XORGFILE="/etc/X11/mhwd.d/nvidia.conf"
-
 post_install()
 {
-    nvidia-xconfig -o "${XORGFILE}" --composite &>/dev/null
-    MHWD_ADD_BACKSPACE "${XORGFILE}"
-
-    # Remove logo
-    sed -i /'Section "Device"'/,/'EndSection'/s/'EndSection'/"\tOption \"NoLogo\" \"1\"\nEndSection"/g "${XORGFILE}"
-
-    mhwd-gpu --setmod nvidia --setxorg "${XORGFILE}"
+    mhwd-gpu --setmod nvidia
 
     if [ ! "$(pgrep X)" ];  then
         modprobe nvidia-drm
@@ -41,19 +33,11 @@ post_install()
     fi
 
     sed -i 's/MODULES=.*/MODULES=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)/g' /etc/mkinitcpio.conf
-    mkinitcpio -P
 }
-
-
 
 post_remove()
 {
-    if [ -e "${XORGFILE}" ]; then
-        rm "${XORGFILE}"
-    fi
-
     sed -i 's/MODULES=.*/MODULES=()/g' /etc/mkinitcpio.conf
-    mkinitcpio -P
     mhwd-gpu --check
 }
 

--- a/pci/graphic_drivers/nvidia-390xx-dkms/MHWDCONFIG
+++ b/pci/graphic_drivers/nvidia-390xx-dkms/MHWDCONFIG
@@ -33,11 +33,13 @@ post_install()
     fi
 
     sed -i 's/MODULES=.*/MODULES=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)/g' /etc/mkinitcpio.conf
+    mkinitcpio -P
 }
 
 post_remove()
 {
     sed -i 's/MODULES=.*/MODULES=()/g' /etc/mkinitcpio.conf
+    mkinitcpio -P
     mhwd-gpu --check
 }
 

--- a/pci/graphic_drivers/nvidia-390xx-dkms/MHWDCONFIG
+++ b/pci/graphic_drivers/nvidia-390xx-dkms/MHWDCONFIG
@@ -31,15 +31,10 @@ post_install()
         modprobe nvidia-drm
         modprobe nvidia-uvm
     fi
-
-    sed -i 's/MODULES=.*/MODULES=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)/g' /etc/mkinitcpio.conf
-    mkinitcpio -P
 }
 
 post_remove()
 {
-    sed -i 's/MODULES=.*/MODULES=()/g' /etc/mkinitcpio.conf
-    mkinitcpio -P
     mhwd-gpu --check
 }
 

--- a/pci/graphic_drivers/nvidia-470xx-dkms/MHWDCONFIG
+++ b/pci/graphic_drivers/nvidia-470xx-dkms/MHWDCONFIG
@@ -23,27 +23,13 @@ DEPENDS="nvidia-470xx-utils nvidia-470xx-settings opencl-nvidia-470xx"
 DEPENDS_64="lib32-nvidia-470xx-utils lib32-opencl-nvidia-470xx"
 DEPKMOD="nvidia-470xx-dkms"
 
-XORGFILE="/etc/X11/mhwd.d/nvidia.conf"
-
 post_install()
 {
-    nvidia-xconfig -o "${XORGFILE}" --composite &>/dev/null
-    MHWD_ADD_BACKSPACE "${XORGFILE}"
-
-    # Remove logo
-    sed -i /'Section "Device"'/,/'EndSection'/s/'EndSection'/"\tOption \"NoLogo\" \"1\"\nEndSection"/g "${XORGFILE}"
-
-    mhwd-gpu --setmod nvidia --setxorg "${XORGFILE}"
-    mkinitcpio -P
+    mhwd-gpu --setmod nvidia
 }
 
 post_remove()
 {
-    if [ -e "${XORGFILE}" ]; then
-        rm "${XORGFILE}"
-    fi
-
-    mkinitcpio -P
     mhwd-gpu --check
 }
 

--- a/pci/graphic_drivers/nvidia-470xx-dkms/MHWDCONFIG
+++ b/pci/graphic_drivers/nvidia-470xx-dkms/MHWDCONFIG
@@ -25,11 +25,13 @@ DEPKMOD="nvidia-470xx-dkms"
 
 post_install()
 {
+    mkinitcpio -P
     mhwd-gpu --setmod nvidia
 }
 
 post_remove()
 {
+    mkinitcpio -P
     mhwd-gpu --check
 }
 

--- a/pci/graphic_drivers/nvidia-470xx-dkms/MHWDCONFIG
+++ b/pci/graphic_drivers/nvidia-470xx-dkms/MHWDCONFIG
@@ -25,13 +25,11 @@ DEPKMOD="nvidia-470xx-dkms"
 
 post_install()
 {
-    mkinitcpio -P
     mhwd-gpu --setmod nvidia
 }
 
 post_remove()
 {
-    mkinitcpio -P
     mhwd-gpu --check
 }
 

--- a/pci/graphic_drivers/nvidia-dkms/MHWDCONFIG
+++ b/pci/graphic_drivers/nvidia-dkms/MHWDCONFIG
@@ -28,17 +28,9 @@ DEPENDS="egl-wayland
 DEPENDS_64="lib32-nvidia-utils lib32-opencl-nvidia"
 CONKMOD="nvidia-dkms"
 
-XORGFILE="/etc/X11/mhwd.d/nvidia.conf"
-
 post_install()
 {
-    nvidia-xconfig -o "${XORGFILE}" --composite &>/dev/null
-    MHWD_ADD_BACKSPACE "${XORGFILE}"
-
-    # Remove logo
-    sed -i /'Section "Device"'/,/'EndSection'/s/'EndSection'/"\tOption \"NoLogo\" \"1\"\nEndSection"/g "${XORGFILE}"
-
-    mhwd-gpu --setmod nvidia --setxorg "${XORGFILE}"
+    mhwd-gpu --setmod nvidia
 
     if [ ! "$(pgrep X)" ];  then
         modprobe nvidia-drm
@@ -48,9 +40,5 @@ post_install()
 
 post_remove()
 {
-    if [ -e "${XORGFILE}" ]; then
-        rm "${XORGFILE}"
-    fi
-
     mhwd-gpu --check
 }

--- a/pci/graphic_drivers/nvidia-prime-render-offload/MHWDCONFIG
+++ b/pci/graphic_drivers/nvidia-prime-render-offload/MHWDCONFIG
@@ -42,14 +42,9 @@ DEPENDS="egl-wayland
          lib32-mesa-vdpau lib32-libva-intel-driver lib32-libva-mesa-driver lib32-libva-vdpau-driver
          lib32-vulkan-mesa-layers"
 
-XORGFILE="/etc/X11/mhwd.d/nvidia.conf"
-
 post_install()
 {
-    # Create an empty Xorg config file, configuration is already provided by nvidia-*-utils
-    MHWD_HEADING "${XORGFILE}"
-
-    mhwd-gpu --setmod nvidia --setxorg "${XORGFILE}"
+    mhwd-gpu --setmod nvidia
 
     if [ ! "$(pgrep X)" ];  then
         modprobe nvidia-drm
@@ -61,8 +56,5 @@ post_install()
 
 post_remove()
 {
-    rm -f "${XORGFILE}"
-    rm -f "${UDEVFILE}"
-
     mhwd-gpu --check
 }


### PR DESCRIPTION
Because the quality of nvidia-xconfig is pretty bad and can cause problems, besides for the newest installations the generation of xorg.conf is no longer required and everything should work out of the box.