### PR TITLE
virtual-machines: Remove qemu-guest-agent.service

### DIFF
--- a/pci/graphic_drivers/profiles.toml
+++ b/pci/graphic_drivers/profiles.toml
@@ -91,8 +91,6 @@ post_install = """
             # Vmware detected
             systemctl enable --now --no-block vmtoolsd.service
         else
-            systemctl enable --now --no-block qemu-guest-agent.service
-
             sed -i 's/MODULES=.*/MODULES=(virtio virtio_blk virtio_pci virtio_net)/g' /etc/mkinitcpio.conf
             mkinitcpio -P
         fi


### PR DESCRIPTION
This service is static and should normally be started by a udev rule (https://github.com/archlinux/svntogit-packages/blob/packages/qemu/trunk/99-qemu-guest-agent.rules)

See also: https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/1883009