### PR TITLE
Fix wrong priorities for old NVIDIA driver versions

### DIFF
--- a/pci/graphic_drivers/profiles.toml
+++ b/pci/graphic_drivers/profiles.toml
@@ -18,7 +18,7 @@ desc = 'Closed source NVIDIA drivers for Linux (Latest)'
 nonfree = true
 class_ids = "0300 0380 0302"
 vendor_ids = "10de"
-priority = 10
+priority = 8
 packages = 'nvidia-dkms nvidia-utils egl-wayland nvidia-settings opencl-nvidia lib32-opencl-nvidia lib32-nvidia-utils libva-nvidia-driver vulkan-icd-loader lib32-vulkan-icd-loader'
 device_ids = '*'
 
@@ -30,7 +30,7 @@ device_name_pattern = '(GK)\w+'
 
 [nvidia-dkms.390xx]
 desc = 'Closed source NVIDIA drivers for Linux (390xx branch, only for Fermi GPUs)'
-priority = 8
+priority = 10
 packages = 'nvidia-390xx-dkms nvidia-390xx-utils nvidia-390xx-settings opencl-nvidia-390xx nvidia-390xx-utils nvidia-390xx-settings opencl-nvidia-390xx lib32-nvidia-390xx-utils lib32-opencl-nvidia-390xx'
 device_name_pattern = '(GF)\w+'
 


### PR DESCRIPTION
Hotfix for an issue where despite finding the profile of old driver, chwd still installs the latest NVIDIA driver because its profile has a higher priority than profile with the old driver.