### PR TITLE
Drop xf86-video-amdgpu driver for AMD profile

### DIFF
--- a/pci/graphic_drivers/profiles.toml
+++ b/pci/graphic_drivers/profiles.toml
@@ -58,7 +58,7 @@ class_ids = "0300 0302"
 vendor_ids = "1002"
 device_ids = "*"
 priority = 4
-packages = 'xf86-video-amdgpu mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon libva-mesa-driver lib32-libva-mesa-driver mesa-vdpau lib32-mesa-vdpau opencl-clover-mesa lib32-opencl-clover-mesa opencl-rusticl-mesa lib32-opencl-rusticl-mesa rocm-opencl-runtime'
+packages = 'mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon libva-mesa-driver lib32-libva-mesa-driver mesa-vdpau lib32-mesa-vdpau opencl-clover-mesa lib32-opencl-clover-mesa opencl-rusticl-mesa lib32-opencl-rusticl-mesa rocm-opencl-runtime'
 
 [fallback]
 desc = 'Fallback profile'


### PR DESCRIPTION
The reason for this is that `xf86-video-amdgpu` doesn't support PRIME Synchronization at all on laptops with PRIME [1][2][3][4]. This leads to the fact that on those configurations where this DDX driver is responsible for controlling external displays, unrecoverable tearing appears. According to the driver maintainer[1] this is an intended behavior, so don't expect it to be fixed in future releases, so let's just drop it. The modesetting is fully functional and works fine on most hardware.

References:
[1] - https://gitlab.freedesktop.org/xorg/driver/xf86-video-amdgpu/-/issues/11#note_478226
[2] - https://bbs.archlinux.org/viewtopic.php?id=270062
[3] - https://wiki.gentoo.org/wiki/AMDGPU#Prime_Synchronization
[4] - https://wiki.archlinux.org/title/PRIME#PRIME_synchronization